### PR TITLE
Allow Cf function to be redeclared

### DIFF
--- a/after/syntax/haskell.vim
+++ b/after/syntax/haskell.vim
@@ -33,7 +33,7 @@
 "
 
 " Cf - check a flag. Return true if the flag is specified.
-function Cf(flag)
+function! Cf(flag)
     return exists('g:hscoptions') && stridx(g:hscoptions, a:flag) >= 0
 endfunction
 


### PR DESCRIPTION
When I switch from one Haskell file to another in Vim I get this error:

![screen shot 2014-08-23 at 10 51 09 am](https://cloud.githubusercontent.com/assets/911911/4021325/249fec82-2aee-11e4-8438-2ed549fafe33.png)

This pull request just follows those instructions and it seems to fix the problem on my machine.
