### PR TITLE
Don't run ++ rule on +++ operator

### DIFF
--- a/after/syntax/haskell.vim
+++ b/after/syntax/haskell.vim
@@ -82,7 +82,7 @@ if s:extraConceal
     syntax match hs_DeclareFunction /^[a-z_(]\S*\(\s\|\n\)*::/me=e-2 nextgroup=hsNiceOperator contains=hs_FunctionName,hs_OpFunctionName
 
     syntax match hsNiceoperator "!!" conceal cchar=‼
-    syntax match hsNiceoperator "++" conceal cchar=⧺
+    syntax match hsNiceoperator "++\ze[^+]" conceal cchar=⧺
     syntax match hsNiceOperator "\<forall\>" conceal cchar=∀
     syntax match hsNiceOperator "-<" conceal cchar=↢
     syntax match hsNiceOperator ">-" conceal cchar=↣


### PR DESCRIPTION
This fixes the issue of `a +++ b` concealing to `a ⧺+ b`. Tested against leading/trailing/both spaces and spaceless cuddles for both operators, and against, e.g. `++++` becoming `⧺⧺` (it doesn't).