### PR TITLE
Don't cuddle composed sum, product, sqrt, not

### DIFF
--- a/after/syntax/haskell.vim
+++ b/after/syntax/haskell.vim
@@ -171,15 +171,15 @@ endif
 
 " 's' option to disable space consumption after ∑,∏,√ and ¬ functions.
 if Cf('s')
-    syntax match hsNiceOperator "\<sum\>"        conceal cchar=∑
-    syntax match hsNiceOperator "\<product\>"    conceal cchar=∏
-    syntax match hsNiceOperator "\<sqrt\>"       conceal cchar=√
-    syntax match hsNiceOperator "\<not\>"        conceal cchar=¬
+    syntax match hsNiceOperator "\<sum\>"                        conceal cchar=∑
+    syntax match hsNiceOperator "\<product\>"                    conceal cchar=∏
+    syntax match hsNiceOperator "\<sqrt\>"                       conceal cchar=√
+    syntax match hsNiceOperator "\<not\>"                        conceal cchar=¬
 else
-    syntax match hsNiceOperator "\<sum\>\s*"     conceal cchar=∑
-    syntax match hsNiceOperator "\<product\>\s*" conceal cchar=∏
-    syntax match hsNiceOperator "\<sqrt\>\s*"    conceal cchar=√
-    syntax match hsNiceOperator "\<not\>\s*"     conceal cchar=¬
+    syntax match hsNiceOperator "\<sum\>\(\ze\s*[.$]\|\s*\)"     conceal cchar=∑
+    syntax match hsNiceOperator "\<product\>\(\ze\s*[.$]\|\s*\)" conceal cchar=∏
+    syntax match hsNiceOperator "\<sqrt\>\(\ze\s*[.$]\|\s*\)"    conceal cchar=√
+    syntax match hsNiceOperator "\<not\>\(\ze\s*[.$]\|\s*\)"     conceal cchar=¬
 endif
 
 " '*' option to enable concealing of asterisk with '⋅' sign.


### PR DESCRIPTION
With space-consuming for these functions enabled, the cuddling of the
operator concealments with following . and $ operators looks strange.

exp: sum [3,4,5] + sum xs
old: ∑[3,4,5] + ∑xs
new: ∑[3,4,5] + ∑xs -- no change for the common case

exp: sum . map product $ [[2,3],[4,5,6]]
old: ∑∘ map ∏$ [[2,3],[4,5,6]] -- cuddling looks odd
new: ∑ ∘ map ∏ $ [[2,3],[4,5,6]] -- fixed