### PR TITLE
Add option to conceal the Natural and Nat types

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ should), put it in *~/.vim/bundle/haskellConcealPlus* folder.
     'B' option to disable Bool type to 𝔹 concealing
     'Q' option to disable Rational type to ℚ concealing
     'Z' option to disable Integer type to ℤ concealing
+    'N' option to disable Natural, Nat types to ℕ concealing
     'D' option to disable Double type to 𝔻 concealing
     'C' option to disable Complex type to ℂ concealing
     '1' option to disable numeric superscripts concealing, e.g. x²

--- a/after/syntax/haskell.vim
+++ b/after/syntax/haskell.vim
@@ -399,6 +399,12 @@ if !Cf('Z')
     syntax match hsNiceOperator "\<Integer\>"  conceal cchar=ℤ
 endif
 
+" 'N' option to disable Natural, Nat types to ℕ concealing.
+if !Cf('N')
+    syntax match hsNiceOperator "\<Natural\>"  conceal cchar=ℕ
+    syntax match hsNiceOperator "\<Nat\>"  conceal cchar=ℕ
+endif
+
 " 'D' option to disable Double type to 𝔻 concealing
 if !Cf('D')
     syntax match hsNiceOperator "\<Double\>"   conceal cchar=𝔻

--- a/after/syntax/lhaskell.vim
+++ b/after/syntax/lhaskell.vim
@@ -399,6 +399,12 @@ if !Cf('Z')
     syntax match hsNiceOperator "\<Integer\>"  conceal cchar=ℤ contained
 endif
 
+" 'N' option to disable Natural, Nat types to ℕ concealing.
+if !Cf('N')
+    syntax match hsNiceOperator "\<Natural\>"  conceal cchar=ℕ contained
+    syntax match hsNiceOperator "\<Nat\>"  conceal cchar=ℕ contained
+endif
+
 " '𝔻' option to disable Double type to 𝔻 concealing
 if !Cf('𝔻')
     syntax match hsNiceOperator "\<Double\>"   conceal cchar=𝔻 contained


### PR DESCRIPTION
Short addition to hide `Natural` and `Nat` with `ℕ`.

I think it goes well with the existing `Integer` hiding and the cases are unlikely to intersect.

If the overlap seems confusing, I'd be happy to remove the `Nat` concealment.